### PR TITLE
add CLI to studio packages

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -19,6 +19,7 @@
     "@cprecioso/country-flag-emoji": "^1.0.0",
     "@heroicons/react": "^1.0.5",
     "@sanity/base": "^2.29.2",
+    "@sanity/cli": "^2.29.2",
     "@sanity/code-input": "^2.29.2",
     "@sanity/core": "^2.28.1",
     "@sanity/default-layout": "^2.29.2",


### PR DESCRIPTION
The CLI has to be installed to run CLI commands. This will make demo-course-platform work seamlessly with Ix.