### PR TITLE
fix: change label in structure

### DIFF
--- a/studio/schemas/documents/labelGroup.ts
+++ b/studio/schemas/documents/labelGroup.ts
@@ -60,4 +60,11 @@ export default defineType({
       ],
     }),
   ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Labels',
+      }
+    },
+  },
 })

--- a/studio/structure/index.ts
+++ b/studio/structure/index.ts
@@ -86,7 +86,6 @@ export const structure: StructureResolver = (S) =>
       S.documentTypeListItem('legal').title('Legal'),
       S.divider(),
       // Singleton, field-level translations
-      // S.documentListItem().schemaType('labelGroup').icon(FiType).id('labelGroup').title('Labels'),
       S.listItem()
         .icon(FiType)
         .id('labelGroup')

--- a/studio/structure/index.ts
+++ b/studio/structure/index.ts
@@ -86,7 +86,13 @@ export const structure: StructureResolver = (S) =>
       S.documentTypeListItem('legal').title('Legal'),
       S.divider(),
       // Singleton, field-level translations
-      S.documentListItem().schemaType('labelGroup').icon(FiType).id('labelGroup').title('Labels'),
+      // S.documentListItem().schemaType('labelGroup').icon(FiType).id('labelGroup').title('Labels'),
+      S.listItem()
+        .icon(FiType)
+        .id('labelGroup')
+        .schemaType('labelGroup')
+        .title('Labels')
+        .child(S.editor().id('labelGroup').schemaType('labelGroup').documentId('labelGroup')),
       S.divider(),
     ])
 


### PR DESCRIPTION
This PR adds a preview to the label doc type in order to remove the ugly default object string.

It also changes the label structure builder item to use `listItem` rather than `documentListItem` to make it prettier. This is subjective as it loses some functionality such as the state indicator. But arguably looks are a higher priority here...