### PR TITLE
Feat/add ai document translations

### DIFF
--- a/studio/package.json
+++ b/studio/package.json
@@ -15,11 +15,11 @@
     "sanity"
   ],
   "dependencies": {
-    "@sanity/assist": "^1.2.15-lang.7",
+    "@sanity/assist": "^2.0.0",
     "@sanity/code-input": "^4.0.0",
-    "@sanity/document-internationalization": "^2.0.1",
+    "@sanity/document-internationalization": "^2.0.3",
     "@sanity/eslint-config-studio": "^2.0.0",
-    "@sanity/language-filter": "^3.1.2",
+    "@sanity/language-filter": "^3.2.2",
     "@sanity/vision": "^3.4.0",
     "eslint": "^8.6.0",
     "eslint-config-prettier": "^8.5.0",
@@ -33,7 +33,7 @@
     "react-icons": "^4.4.0",
     "react-is": "^18.2.0",
     "react-xarrows": "^2.0.2",
-    "sanity": "^3.18.0",
+    "sanity": "^3.29.1",
     "sanity-plugin-documents-pane": "^2.0.0",
     "sanity-plugin-google-translate": "^3.0.0",
     "sanity-plugin-iframe-pane": "^2.0.0",

--- a/studio/sanity.config.tsx
+++ b/studio/sanity.config.tsx
@@ -21,7 +21,7 @@ export default defineConfig({
   name: 'default',
   title: 'Course Platform',
   projectId: '6h1mv88x',
-  dataset: 'production-v3',
+  dataset: 'production-v3-ken-dev',
   icon: Icon,
   theme,
 
@@ -83,6 +83,10 @@ export default defineConfig({
         field: {
           documentTypes: ['presenter'],
           languages: i18n.languages,
+        },
+        document: {
+          languageField: 'language',
+          documentTypes: ['lesson'],
         },
       },
     }),

--- a/studio/sanity.config.tsx
+++ b/studio/sanity.config.tsx
@@ -21,7 +21,7 @@ export default defineConfig({
   name: 'default',
   title: 'Course Platform',
   projectId: '6h1mv88x',
-  dataset: 'production-v3-ken-dev',
+  dataset: 'production-v3',
   icon: Icon,
   theme,
 


### PR DESCRIPTION
Adding AI-Assist document level translations to the `lessons` _type documents.  I also update a few related dependancies.

Upon approving this (if its ready), you might want to:
- [ ] Remove the existing document level "Translate" AI-Assist command from the studio.
- [ ] Remove the existing field level "Translate" AI-Assist command on the `title` field.