### PR TITLE
Tiny fix to address presenter name and title - currently glued together on main

### DIFF
--- a/web/components/Clean.tsx
+++ b/web/components/Clean.tsx
@@ -20,6 +20,6 @@ export default function Clean({value, as}: CleanProps) {
       <span style={{display: 'none'}}>{encoded}</span>
     </Element>
   ) : (
-    cleaned
+    <Element>{cleaned}</Element>
   )
 }


### PR DESCRIPTION
<img width="541" alt="image" src="https://github.com/user-attachments/assets/52417809-c7ad-4823-af0c-93bfd2a7f85a">
